### PR TITLE
Use `external_link_to` for GA support site links

### DIFF
--- a/app/views/spree/admin/integrations/forms/_google_analytics.html.erb
+++ b/app/views/spree/admin/integrations/forms/_google_analytics.html.erb
@@ -8,11 +8,8 @@
       <% end %>
 
       <%= preference_field(@integration, form, 'measurement_id', i18n_scope: 'admin.integrations.google_analytics') %>
-      <p class="mb-0 mt-n2">
-        <%= link_to 'https://support.google.com/analytics/answer/12270356', target: "_blank", class: 'btn btn-link' do %>
-          Where to find my Measurement ID?
-          <%= icon('external-link', class: 'ml-2 mr-0') %>
-        <% end %>
+      <p class="mb-0 mt-2">
+        <%= external_link_to 'Where to find my Measurement ID?', 'https://support.google.com/analytics/answer/12270356' %>
       </p>
     </div>
   </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the appearance and spacing of the Google Analytics integration link in the admin interface for improved consistency.
- **Refactor**
  - Simplified the external link by using a helper method, resulting in cleaner and more maintainable code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->