### PR TITLE
Include `BaseHelper` in devise controllers

### DIFF
--- a/app/controllers/spree_google_analytics/store_controller_decorator.rb
+++ b/app/controllers/spree_google_analytics/store_controller_decorator.rb
@@ -7,3 +7,14 @@ module SpreeGoogleAnalytics
 end
 
 Spree::StoreController.prepend(SpreeGoogleAnalytics::StoreControllerDecorator) if defined?(Spree::StoreController)
+
+# include in Devise controllers
+if defined?(Spree::UserSessionsController)
+  Spree::UserSessionsController.prepend(SpreeGoogleAnalytics::UserSessionsControllerDecorator)
+end
+if defined?(Spree::UserRegistrationsController)
+  Spree::UserRegistrationsController.prepend(SpreeGoogleAnalytics::UserRegistrationsControllerDecorator)
+end
+if defined?(Spree::UserPasswordsController)
+  Spree::UserPasswordsController.prepend(SpreeGoogleAnalytics::UserPasswordsControllerDecorator)
+end

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+RSpec.describe 'Home Page', type: :feature do
+  describe 'visiting the home page' do
+    before do
+      visit '/'
+    end
+
+    it 'loads successfully' do
+      expect(page.status_code).to eq(200)
+    end
+  end
+end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Expanded analytics coverage to include sign-in, sign-up, and password reset flows when those pages are present, extending visibility into user authentication journeys without impacting stores that don’t use them.

- Tests
  - Added a feature test to confirm the home page loads successfully (HTTP 200), helping ensure core storefront availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->