### PR TITLE
Update admin form initial revealed input

### DIFF
--- a/app/views/spree/admin/integrations/forms/_google_analytics.html.erb
+++ b/app/views/spree/admin/integrations/forms/_google_analytics.html.erb
@@ -8,12 +8,12 @@
 
     <%= form.spree_collection_select "preferred_client", [['Google Analytics 4', 'ga4'], ['Google Tag Manager', 'gtm']], :last, :first, { selected: @integration.preferred_client, label: Spree.t('admin.integrations.google_analytics.client'), help: Spree.t('admin.integrations.google_analytics.client_help') }, { data: { action: 'change->reveal#toggle' } } %>
 
-    <div data-reveal-target="item">
+    <div class="<%= class_names(hidden: @integration.preferred_client == 'gtm') %>" data-reveal-target="item">
       <%= preference_field(@integration, form, 'measurement_id', i18n_scope: 'admin.integrations.google_analytics') %>
       <%= external_link_to 'Where to find my Measurement ID?', 'https://support.google.com/analytics/answer/12270356' %>
     </div>
 
-    <div class="hidden" data-reveal-target="item">
+    <div class="<%= class_names(hidden: @integration.preferred_client == 'ga4') %>" data-reveal-target="item">
       <%= preference_field(@integration, form, 'google_tag_manager_id', i18n_scope: 'admin.integrations.google_analytics') %>
       <%= external_link_to 'Where to find my Google Tag Manager ID?', 'https://support.google.com/tagmanager/answer/6107028' %>
       </div>


### PR DESCRIPTION
Previously GA4 was always revealed on initial load, causing wrong input being opened when GTM was set as preferred client and toggling it would keep that wrong behaviour.

With this change it reveals correct form input based on the preferred client.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conditional visibility of Google Analytics integration form fields based on the selected client type (GTM or GA4). Form sections now properly display or hide depending on your client preference selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->